### PR TITLE
Handling the 404 router with react-router and route-wrapper

### DIFF
--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -35,15 +35,15 @@ export default ({ server, config }) => {
       // How would we error out if two routes match here? "Ambigous routes detected?" maybe earlier in app
       const branch = matchRoutes(routes, request.url.pathname)
       // This needs tidying
-      let route, match
-      // Optimistic default component data for static routes
-      let componentData = {
-        status: 200,
-        message: '200'
-      }
+      let route, match, componentData
       let fetchRequestHasErrored = false
       // If there's a branch of the route config, we have a route
       if (branch[0]) {
+        // Optimistic default component data for static routes
+        componentData = {
+          status: 200,
+          message: '200'
+        }
         // Assign the route object
         route = branch[0].route
         // Assign the match object for the route
@@ -82,13 +82,10 @@ export default ({ server, config }) => {
         if (routeComponentUndefined || (fetchRequestHasErrored && !allowEmptyResponse)) {
           route.component = buildErrorView({config, missing: routeComponentUndefined})
         }
-      } else { // end of route match block
-        // No routes match, so we kick off rendering a 404 page
-        // Create a fake route object with an error view,
-        // and add componentData with 404 status and message
-        route = {
-          component: buildErrorView({config, missing: false})
-        }
+      }
+      // If our route is the not found route
+      // Overwrite the data
+      if (route.notFoundRoute) {
         componentData = {
           message: 'Not Found',
           code: 404

--- a/src/server/routing/route-wrapper.js
+++ b/src/server/routing/route-wrapper.js
@@ -1,18 +1,28 @@
 import React from 'react'
 import { Route } from 'react-router'
 import HTTPStatus from 'http-status'
-
 import defaultRoutes from './default-routes'
+import buildErrorView from '../render/error-view'
 
 const RouteWrapper = config => {
   // if user routes have been defined, take those in preference to the defaults
   const routes = config.routes || defaultRoutes(config.components)
-  return routes.map(route => {
+  let routesWithExact = routes.map(route => {
     return {
       ...route,
       exact: true
     }
   })
+  // Add the a default 404 route
+  routesWithExact.push({
+    path: '/*',
+    notFoundRoute: true,
+    component: buildErrorView({
+      config,
+      missing: false
+    })
+  })
+  return routesWithExact
 }
 
 export default RouteWrapper


### PR DESCRIPTION
Adding the catch all 404 route during  the Route Wrapping process to cut down on dynamic handler logic.

This cut down of logic is not yet apparent. But it will be!