### PR TITLE
Removed getComponent support

### DIFF
--- a/src/server/render/tree-to-html.js
+++ b/src/server/render/tree-to-html.js
@@ -4,13 +4,7 @@ import Helmet from 'react-helmet'
 import idx from 'idx'
 
 export default async ({ route, match, componentData }) => {
-  // go fetch getComponent: () => import()
-  let Component = route.component
-  if (typeof route.getComponent === 'function') {
-    const module = await route.getComponent()
-    Component = module.default || module
-  }
-  const htmlString = renderToString(<Component {...match} {...componentData} />)
+  const htmlString = renderToString(<route.component {...match} {...componentData} />)
   // { html, css, ids }
   let styleData = {}
   // extract CSS from either Glamor or Emotion


### PR DESCRIPTION
We should replace this with `react-loadable` once we wrap our heads around it.