### PR TITLE
Replace react-router matchRoutes with utility script

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,6 @@
     "react-error-overlay": "^4.0.0",
     "react-helmet": "^5.2.0",
     "react-hot-loader": "^4.0.0",
-    "react-router": "^4.2.0",
-    "react-router-config": "^1.0.0-beta.4",
     "redis-parser": "^3.0.0",
     "source-map-support": "^0.5.4",
     "start-server-webpack-plugin": "^2.2.1",

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { hot } from 'react-hot-loader'
-import { matchRoutes } from 'react-router-config'
 
 import prepareAppRoutes from '../server/routing/prepare-app-routes'
 import buildErrorView from '../server/render/error-view'
+import matchRoutes from '../server/utilities/match-routes'
 
 const Root = config => {
   if (window.__data.appData.code === 404) {
@@ -12,6 +12,7 @@ const Root = config => {
   }
   const routes = prepareAppRoutes(config)
   const { route, match } = matchRoutes(routes, window.location.pathname)[0]
+  console.log({ route, match })
   return <route.component {...match} {...window.__data.appData} />
 }
 

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -12,7 +12,6 @@ const Root = config => {
   }
   const routes = prepareAppRoutes(config)
   const { route, match } = matchRoutes(routes, window.location.pathname)[0]
-  console.log({ route, match })
   return <route.component {...match} {...window.__data.appData} />
 }
 

--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -1,9 +1,9 @@
-import { matchRoutes } from 'react-router-config'
 import idx from 'idx'
 
 import baseUrlResolver from '../utilities/base-url-resolver'
 import { log } from '../utilities/logger'
 import CacheManager from '../utilities/cache-manager'
+import matchRoutes from '../utilities/match-routes'
 
 import prepareAppRoutes from '../routing/prepare-app-routes'
 

--- a/src/server/routing/prepare-app-routes.js
+++ b/src/server/routing/prepare-app-routes.js
@@ -12,7 +12,6 @@ export default config => {
   })
   // Add the a default 404 route
   preparedRoutes.push({
-    path: '/*',
     notFoundRoute: true,
     component: buildErrorView({
       config,

--- a/src/server/utilities/match-routes.js
+++ b/src/server/utilities/match-routes.js
@@ -1,0 +1,84 @@
+import pathToRegexp from 'path-to-regexp'
+
+const patternCache = {}
+const cacheLimit = 10000
+let cacheCount = 0
+
+const compilePath = (pattern, options) => {
+  const cacheKey = `${options.end}${options.strict}${options.sensitive}`
+  const cache = patternCache[cacheKey] || (patternCache[cacheKey] = {})
+
+  if (cache[pattern]) return cache[pattern]
+
+  const keys = []
+  const re = pathToRegexp(pattern, keys, options)
+  const compiledPattern = { re, keys }
+
+  if (cacheCount < cacheLimit) {
+    cache[pattern] = compiledPattern
+    cacheCount++
+  }
+
+  return compiledPattern
+}
+
+/**
+ * Public API for matching a URL pathname to a path pattern.
+ */
+const matchPath = (pathname, options = {}, parent) => {
+  if (typeof options === 'string') options = { path: options }
+
+  const { path, exact = false, strict = false, sensitive = false } = options
+
+  if (path == null) return parent
+
+  const { re, keys } = compilePath(path, { end: exact, strict, sensitive })
+  const match = re.exec(pathname)
+
+  if (!match) return null
+
+  const [url, ...values] = match
+  const isExact = pathname === url
+
+  if (exact && !isExact) return null
+
+  return {
+    path, // the path pattern used to match
+    url: path === '/' && url === '' ? '/' : url, // the matched portion of the URL
+    isExact, // whether or not we matched exactly
+    params: keys.reduce((memo, key, index) => {
+      memo[key.name] = values[index]
+      return memo
+    }, {})
+  }
+}
+
+const matchRoutes = (routes, pathname, /*not public API*/ branch = []) => {
+  routes.some(route => {
+    // console.log({ matchPath: matchPath(pathname, route) })
+    const match = route.path
+      ? matchPath(pathname, route)
+      : branch.length
+        ? branch[branch.length - 1].match // use parent match
+        : {
+            path: '/',
+            url: '/',
+            params: {},
+            isExact: pathname === '/'
+          } // use default "root" match
+
+    if (match) {
+      branch.push({ route, match })
+
+      if (route.routes) {
+        matchRoutes(route.routes, pathname, branch)
+      }
+    }
+
+    return match
+  })
+
+  return branch
+}
+
+export default matchRoutes

--- a/yarn.lock
+++ b/yarn.lock
@@ -3316,7 +3316,7 @@ hoek@5.x.x:
   version "5.0.3"
   resolved "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz#b71d40d943d0a95da01956b547f83c4a5b4a34ac"
 
-hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -5078,12 +5078,6 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  dependencies:
-    isarray "0.0.1"
-
 path-to-regexp@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.0.tgz#80f0ff45c1e0e641da74df313644eaf115050972"
@@ -5492,22 +5486,6 @@ react-hot-loader@^4.0.0:
     hoist-non-react-statics "^2.5.0"
     prop-types "^15.6.0"
     shallowequal "^1.0.2"
-
-react-router-config@^1.0.0-beta.4:
-  version "1.0.0-beta.4"
-  resolved "https://registry.npmjs.org/react-router-config/-/react-router-config-1.0.0-beta.4.tgz#d202496dd0eabdf06cf24eb0793031f6891eef01"
-
-react-router@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"
-  dependencies:
-    history "^4.7.2"
-    hoist-non-react-statics "^2.3.0"
-    invariant "^2.2.2"
-    loose-envify "^1.3.1"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.5.4"
-    warning "^3.0.0"
 
 react-side-effect@^1.1.0:
   version "1.1.5"


### PR DESCRIPTION
This is copied directly from `react-router`, had to tweak the 404 catch-all route to fall through correctly.