### PR TITLE
Handle API 404 and error view

### DIFF
--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -87,6 +87,7 @@ export default ({ server, config }) => {
       // an empty response is not allowed, we replace the route component
       // with our error view component
       if (
+        componentData.code === 404 ||
         routeComponentUndefined ||
         (fetchRequestHasErrored && !allowEmptyResponse)
       ) {


### PR DESCRIPTION
No idea how/why this worked before. This seems like it could be the weird server 404 bug.