### PR TITLE
CSS Migration Mode

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -4,7 +4,14 @@ import config from '../config/config-proxy'
 import Root from './root'
 
 // Hydrate server rendered CSS with either Emotion or Glamor
-if (CSS_PLUGIN === 'emotion') require('emotion').hydrate(window.__data.ids)
-if (CSS_PLUGIN === 'glamor') require('glamor').rehydrate(window.__data.ids)
+if (CSS_PLUGIN === 'emotion')
+  require('emotion').hydrate(window.__data.ids.emotion)
+if (CSS_PLUGIN === 'glamor')
+  require('glamor').rehydrate(window.__data.ids.glamor)
+// Mad migration mode
+if (CSS_PLUGIN === 'migration') {
+  require('emotion').hydrate(window.__data.ids.emotion)
+  require('glamor').rehydrate(window.__data.ids.glamor)
+}
 
 hydrate(<Root {...config} />, document.getElementById('root'))

--- a/src/server/render/tree-to-html.js
+++ b/src/server/render/tree-to-html.js
@@ -10,17 +10,34 @@ export default async ({
 }) => {
   const htmlString = renderToString(<Component {...match} {...componentData} />)
   // { html, css, ids }
-  let styleData = {}
+  let glamorData = {
+    css: ''
+  }
+  let emotionData = {
+    css: ''
+  }
   // extract CSS from either Glamor or Emotion
   if (process.env.CSS_PLUGIN === 'emotion') {
-    styleData = require('emotion-server').extractCritical(htmlString)
+    emotionData = require('emotion-server').extractCritical(htmlString)
+  } else if (process.env.CSS_PLUGIN === 'migration') {
+    emotionData = require('emotion-server').extractCritical(htmlString)
+    glamorData = require('glamor/server').renderStaticOptimized(
+      () => htmlString
+    )
   } else {
-    styleData = require('glamor/server').renderStaticOptimized(() => htmlString)
+    glamorData = require('glamor/server').renderStaticOptimized(
+      () => htmlString
+    )
   }
   const helmet = Helmet.renderStatic()
   // Assets to come, everything else works
   const renderData = {
-    ...styleData,
+    html: htmlString,
+    css: `${glamorData.css} ${emotionData.css}`,
+    ids: {
+      glamor: glamorData.ids,
+      emotion: emotionData.ids
+    },
     head: helmet,
     bootstrapData: componentData
   }


### PR DESCRIPTION
Hacked up a little thoughtlet PR:

> What if you could start writing new components with Emotion and have your legacy components render with Glamor?

I need to do some client-side testing around Client-side CSS updates (styles dependent on interaction and component state), but the SSR implementation works. Edit: (I have now done this see below)

I'll also need to check what adding Emotion and Glamor does to bundle sizes.

> *I've done this*: It added 24kb to the vendor bundle. Something to bear in mind but potentially a worthy trade off to use a snazzier CSS-In-JS solution sooner.

This might be a dumb idea and migrating a project manually might be less faff...

Here's the client test:

```js
import React from 'react'
import styled from 'react-emotion'
import { css } from 'glamor'

class Test extends React.Component {
  constructor() {
    super()
    this.state = {
      color: 'red'
    }
  }
  componentDidMount() {
    setInterval(() => {
      this.setState({color: (this.state.color === 'red') ? 'blue' : 'red'})
      console.log(this.state.color)
    }, 1000)
  }

  render() {
    const EmotionText = styled('p')`
      color: ${this.state.color}
    `
    return (
      <div>
        <EmotionText>Red</EmotionText>
        <p className={css({color: this.state.color})}>
          Blue
        </p>
      </div>
    )
  }
}

export default Test
```

And here's the result:

![emotion-and-glamor](https://user-images.githubusercontent.com/631670/39213470-90126012-4809-11e8-83ec-e18abf279796.gif)

Glamor and Emotion doing their thing simultaneously! Pretty mental, but would let us crack on writing Emotion powered stuff in legacy projects.

## Bundle size on legacy project (ray) using only glamor:

<img width="403" alt="screen shot 2018-04-25 at 22 22 26" src="https://user-images.githubusercontent.com/631670/39273614-41dd3e2a-48d7-11e8-8703-d935726e3aba.png">

## Bundle size on legacy project (ray) using in migration mode (glamor and emotion)

<img width="459" alt="screen shot 2018-04-25 at 22 22 38" src="https://user-images.githubusercontent.com/631670/39273655-5839af0a-48d7-11e8-90e7-2dbee758e66f.png">

