### PR TITLE
Byte savin

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "lodash.isfunction": "^3.0.9",
     "lodash.isplainobject": "^4.0.6",
     "make-promises-safe": "^1.1.0",
+    "matchit": "^1.0.6",
     "path-to-regexp": "^2.2.0",
     "ps-tree": "^1.1.0",
     "razzle-dev-utils": "^2.0.0-alpha.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "lodash.isplainobject": "^4.0.6",
     "make-promises-safe": "^1.1.0",
     "matchit": "^1.0.6",
-    "path-to-regexp": "^2.2.0",
     "ps-tree": "^1.1.0",
     "razzle-dev-utils": "^2.0.0-alpha.2",
     "react-dev-utils": "5.0.1",

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -6,7 +6,7 @@ import matchRoutes from '../server/routing/match-routes'
 import buildErrorView from '../server/render/error-view'
 
 const log = (msg, data) =>
-  window.location.search.indexOf('debug') !== -1 && console.log(msg, data)
+  window.location.hash.indexOf('development') !== -1 && console.log(msg, data)
 
 const Root = config => {
   log(`Application data`, window.__data)
@@ -18,7 +18,7 @@ const Root = config => {
     prepareAppRoutes(config),
     window.location.pathname
   )
-  log('Matched route', route)
+  log('Matched route', { route, match })
   return <route.component {...match} {...window.__data.appData} />
 }
 

--- a/src/server/render/default-document/index.js
+++ b/src/server/render/default-document/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import fs from 'fs-extra'
 import path from 'path'
-import PropTypes from 'prop-types'
 
 import stringifyEscapeScript from '../../utilities/stringify-escape-script'
 
@@ -42,12 +41,5 @@ const DefaultDocument = ({ html, css, ids, head, bootstrapData }) => (
     </body>
   </html>
 )
-
-DefaultDocument.propTypes = {
-  bootstrapData: PropTypes.object.isRequired,
-  css: PropTypes.string.isRequired,
-  head: PropTypes.object.isRequired,
-  html: PropTypes.string.isRequired
-}
 
 export default DefaultDocument

--- a/src/server/render/default-error/index.js
+++ b/src/server/render/default-error/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const DefaultError = ({ message, code, children }) => (
   <section
     style={{
       backgroundColor: '#f9f9f9',
+      color: '#c0c0c0',
       fontFamily: 'Helvetica, sans-serif',
+      fontWeight: 'bold',
       minHeight: '100vh',
       padding: '80px',
       width: '100vw'
@@ -31,41 +32,14 @@ const DefaultError = ({ message, code, children }) => (
         d="M7.6 20.67h1.93v18.3H7.4c-.9.04-1.75.3-1.75.3V21.6s.86-.95 1.94-.95zm5.46-11.3h3.88V27.7h-3.88V9.38zm14.82.03h3.88v18.3h-3.88V9.4zm14.83 0h3.9v18.3h-3.9V9.4zm7.5 11.3h2.4c.8 0 1.5-.22 1.5-.22v18s-.4.44-1.73.5H50.2v-18.3zM13.1 31.94H17v18.3h-3.9v-18.3zm14.8.06h3.88v18.2H27.9V32zm14.83-.04h3.9v18.3h-3.9v-18.3zm-22.2-11.3h3.9v18.3h-3.9v-18.3zm14.83 0h3.88v18.3h-3.9v-18.3zM7.46 43.24H9.5V57.6c0 1.07-.87 1.95-1.94 1.95-1.08 0-1.95-.88-1.95-1.96V43.9s.5-.62 1.8-.73zM52.2 16.36h-2.1V2.14c0-1.08.87-1.96 1.94-1.96 1.07 0 1.94.88 1.94 1.96V15.9s-.72.47-1.8.47z"
       />
     </svg>
-    {code && (
-      <p
-        style={{
-          color: '#c0c0c0',
-          fontSize: '28px',
-          fontWeight: 'bold',
-          marginBottom: '10px',
-          marginTop: '20px'
-        }}
-      >
-        {code}
-      </p>
-    )}
-    <h1
-      style={{
-        color: '#c0c0c0',
-        fontSize: '18px',
-        fontWeight: 'bold',
-        marginBottom: '40px'
-      }}
-    >
-      {message}
-    </h1>
+    {code && <p style={{ fontSize: '28px', marginBottom: '10px' }}>{code}</p>}
+    <h1 style={{ fontSize: '18px', marginBottom: '40px' }}>{message}</h1>
     {children}
   </section>
 )
 
 DefaultError.defaultProps = {
   message: 'Application Error'
-}
-
-DefaultError.propTypes = {
-  message: PropTypes.string,
-  code: PropTypes.number,
-  children: PropTypes.node
 }
 
 export default DefaultError

--- a/src/server/render/error-view.js
+++ b/src/server/render/error-view.js
@@ -1,14 +1,18 @@
-import idx from 'idx'
 import DefaultError from './default-error'
 import MissingView from './missing-view'
 
-export default ({ config, missing }) => {
+export default ({ config = {}, missing = false }) => {
   // render custom error or default if custom error not declared
-  let ErrorView = idx(config, _ => _.components.CustomError)
-    ? config.components.CustomError
-    : DefaultError
+  let ErrorView =
+    config.components && config.components.CustomError
+      ? config.components.CustomError
+      : DefaultError
   // render missing component only in DEV
-  if (['test', 'development'].includes(process.env.NODE_ENV) && missing) {
+  if (
+    (process.env.NODE_ENV === 'test' ||
+      process.env.NODE_ENV === 'development') &&
+    missing
+  ) {
     ErrorView = MissingView
   }
   // return one of the error views

--- a/src/server/render/missing-view/index.js
+++ b/src/server/render/missing-view/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import DefaultError from '../default-error'
 
 const MissingView = response => (
@@ -9,7 +8,4 @@ const MissingView = response => (
   </DefaultError>
 )
 
-MissingView.propTypes = {
-  response: PropTypes.object
-}
 export default MissingView

--- a/src/server/routing/match-routes.js
+++ b/src/server/routing/match-routes.js
@@ -1,48 +1,17 @@
-import pathToRegexp from 'path-to-regexp'
+import { exec, match, parse } from 'matchit'
 
-const compilePath = (pattern, options) => {
-  const keys = []
-  const re = pathToRegexp(pattern, keys, options)
-  return { re, keys }
-}
-
-const matchPath = (pathname, route = {}) => {
-  const { path = '', exact = false, strict = false, sensitive = false } = route
-
-  const { re, keys } = compilePath(path, { end: exact, strict, sensitive })
-  const match = re.exec(pathname)
-
-  if (!match) return null
-
-  const [url, ...values] = match
-  const isExact = pathname === url
-
-  if (exact && !isExact) return null
-
+export default (routes, pathname) => {
+  // returns matchit object schema
+  // e.g. [{ old:'/', type:0, val:'/' }]
+  const matchedRoute = match(
+    pathname,
+    routes.map(route => route.path).map(parse)
+  )
   return {
-    path, // the path pattern used to match
-    url: path === '/' && url === '' ? '/' : url, // the matched portion of the URL
-    isExact, // whether or not we matched exactly
-    params: keys.reduce((memo, key, index) => {
-      memo[key.name] = values[index]
-      return memo
-    }, {})
+    route: routes.filter(({ path }) => matchedRoute[0].old === path)[0],
+    match: {
+      path: pathname,
+      params: exec(pathname, matchedRoute)
+    }
   }
 }
-
-const matchRoutes = (routes, pathname) => {
-  const branch = []
-
-  routes.some(route => {
-    const match = matchPath(pathname, route)
-    if (match) branch.push({ route, match })
-    return match
-  })
-
-  if (branch.length > 1)
-    console.error('Multiple routes matched, returning first match')
-
-  return branch[0]
-}
-
-export default matchRoutes

--- a/src/server/routing/prepare-app-routes.js
+++ b/src/server/routing/prepare-app-routes.js
@@ -1,19 +1,14 @@
-import buildErrorView from '../render/error-view'
+import errorView from '../render/error-view'
 
 export default config => {
   let routes = config.routes
   // import and use default routes if user has not defined any routes
   if (!routes) routes = require('./default-routes').default(config.components)
-  // each route needs to be unambiguous
-  const preparedRoutes = routes.map(route => ({ ...route, exact: true }))
-  // add the a default 404 route
-  preparedRoutes.push({
+  // add a default "not found" route
+  routes.push({
     path: '/*',
     notFoundRoute: true,
-    component: buildErrorView({
-      config,
-      missing: false
-    })
+    component: errorView({ config })
   })
-  return preparedRoutes
+  return routes
 }

--- a/src/server/routing/prepare-app-routes.js
+++ b/src/server/routing/prepare-app-routes.js
@@ -8,7 +8,7 @@ export default config => {
   const preparedRoutes = routes.map(route => ({ ...route, exact: true }))
   // add the a default 404 route
   preparedRoutes.push({
-    path: '(.*)',
+    path: '/*',
     notFoundRoute: true,
     component: buildErrorView({
       config,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5399,10 +5399,6 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.0.tgz#80f0ff45c1e0e641da74df313644eaf115050972"
-
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@arr/every@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@arr/every/-/every-1.0.0.tgz#314f8168f50ae48a032cfdad5fdb436f464a97ac"
+
 "@babel/code-frame@7.0.0-beta.42", "@babel/code-frame@^7.0.0-beta.40":
   version "7.0.0-beta.42"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz#a9c83233fa7cd06b39dc77adbb908616ff4f1962"
@@ -4671,6 +4675,12 @@ map-visit@^1.0.0:
   resolved "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+matchit@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/matchit/-/matchit-1.0.6.tgz#825da06468bd324f0219ebe28e12a41bfb5524c4"
+  dependencies:
+    "@arr/every" "^1.0.0"
 
 md5.js@^1.3.4:
   version "1.3.4"


### PR DESCRIPTION
* Replaced `path-to-regexp` and logic with [`matchit`](https://github.com/lukeed/matchit), a smaller/faster alternative.
* Updated in browser debugging to `#development` to match AMP, thoughts?
* Removed all `prop-types`
* Removed `idx` from the single place it was used in the client bundle
* Simplified `prepare-app-routes.js` as we no longer need `exact: true`