### PR TITLE
Verbose console output all the time

### DIFF
--- a/src/config/createWebpackConfig.js
+++ b/src/config/createWebpackConfig.js
@@ -38,7 +38,7 @@ const nodeDevPlugins = [
   new FriendlyErrorsPlugin({
     target: 'node',
     onSuccessMessage: 'Tapestry Lite is Running',
-    verbose: process.env.NODE_ENV === 'test'
+    verbose: true
   })
 ]
 


### PR DESCRIPTION
Two compilers - both clearing the console output

1. Error in the server compiler
2. Success in the client compiler
3. Client compiler clears output
4. Can't see the server error
5. Set the environment to test so you can see the error

