### PR TITLE
Add disable doctype option

### DIFF
--- a/src/server/render/tree-to-html.js
+++ b/src/server/render/tree-to-html.js
@@ -30,5 +30,7 @@ export default async ({
   }
   let Document =
     routeOptions.customDocument || require('../render/default-document').default
-  return `<!doctype html>${renderToStaticMarkup(<Document {...renderData} />)}`
+  return `${
+    routeOptions.disableDoctype ? '' : '<!doctype html>'
+  }${renderToStaticMarkup(<Document {...renderData} />)}`
 }

--- a/test/server/document.test.js
+++ b/test/server/document.test.js
@@ -40,6 +40,14 @@ describe('Document contents', () => {
         }
       },
       {
+        path: '/custom-document-no-doctype',
+        component: () => <p>Custom HTML</p>,
+        options: {
+          customDocument: () => 'testing-document',
+          disableDoctype: true
+        }
+      },
+      {
         path: '/custom-document/with-data',
         endpoint: () => 'posts',
         component: () => (
@@ -147,6 +155,14 @@ describe('Document contents', () => {
     request.get(`${uri}/custom-document`, (err, res, body) => {
       expect(body).to.contain('testing-document')
       expect(body).to.contain('<!doctype html>')
+      done()
+    })
+  })
+
+  it('Custom document can have doctype disabled', done => {
+    request.get(`${uri}/custom-document-no-doctype`, (err, res, body) => {
+      expect(body).to.contain('testing-document')
+      expect(body).to.not.contain('<!doctype html>')
       done()
     })
   })


### PR DESCRIPTION
Allows us to manage a lot of validation procedures from AWS, Google, Facebook etc through tapestry.