### PR TITLE
Feature/query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-# 1.3.2 (08-06-2018)
+# 1.4.0 (08-06-2018)
 
-* make request data available in `window.__TAPESTRY_DATA__`
+* Changed schema of `window.__TAPESTRY_DATA__`. Now includes request data and params. This is means that where previously you'd access `props.params` in the top level component, you'll now use `props._tapestry.requestData.params`
 
 # 1.3.1 (07-06-2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# 1.3.2 (08-06-2018)
+
+* make request data available in `window.__TAPESTRY_DATA__`
+
 # 1.3.1 (07-06-2018)
 
 * Fixed Loadable Components initial server render

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "prepublishOnly": "npm run lint && npm run test",
     "lint": "eslint . --fix --cache",
     "test": "HOST=localhost npm run test:server && npm run test:integration",
-    "test:server": "NODE_ENV=test LOG_LEVEL=silent mocha ./src/**/*.test.js ./test/server/*.test.js --require test/babel-register --bail",
-    "test:integration": "PORT=4321 NODE_ENV=test LOG_LEVEL=silent mocha ./test/integration/*.test.js --require test/babel-register --bail"
+    "test:server": "NODE_ENV=test LOG_LEVEL=silent mocha ./src/**/*.test.js ./test/server/*.test.js --require test/babel-register",
+    "test:integration": "PORT=4321 NODE_ENV=test LOG_LEVEL=silent mocha ./test/integration/*.test.js --require test/babel-register"
   },
   "license": "ISC",
   "devDependencies": {

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -19,7 +19,12 @@ const Root = config => {
     window.location.pathname
   )
   log('Matched route', { route, match })
-  return <route.component {...window.__TAPESTRY_DATA__.appData} />
+  return (
+    <route.component
+      {...window.__TAPESTRY_DATA__.appData}
+      {...window.__TAPESTRY_DATA__._tapestry}
+    />
+  )
 }
 
 export default hot(module)(Root)

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -22,7 +22,7 @@ const Root = config => {
   return (
     <route.component
       {...window.__TAPESTRY_DATA__.appData}
-      {...window.__TAPESTRY_DATA__._tapestry}
+      _tapestry={window.__TAPESTRY_DATA__._tapestry}
     />
   )
 }

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -19,7 +19,7 @@ const Root = config => {
     window.location.pathname
   )
   log('Matched route', { route, match })
-  return <route.component {...match} {...window.__TAPESTRY_DATA__.appData} />
+  return <route.component {...window.__TAPESTRY_DATA__.appData} />
 }
 
 export default hot(module)(Root)

--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -37,7 +37,7 @@ const renderErrorTree = async ({
 }
 
 const renderSuccessTree = async (
-  { route, match, componentData, isPreview, h, requestParams },
+  { route, match, componentData, isPreview, h, queryParams },
   cache,
   cacheKey
 ) => {
@@ -48,7 +48,7 @@ const renderSuccessTree = async (
     routeOptions: route.options,
     match,
     componentData,
-    requestParams
+    queryParams
   })
   const response = h
     .response(responseString)
@@ -96,7 +96,7 @@ export default ({ server, config }) => {
           .code(200)
       }
 
-      const requestParams = request.query
+      const queryParams = request.query
 
       // Don't even import react-router any more, but backwards compatible
       // With the exception of optional params: (:thing) becomes :thing?
@@ -182,7 +182,7 @@ export default ({ server, config }) => {
           componentData,
           isPreview,
           h,
-          requestParams
+          queryParams
         },
         cache,
         cacheKey

--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -37,7 +37,7 @@ const renderErrorTree = async ({
 }
 
 const renderSuccessTree = async (
-  { route, match, componentData, isPreview, h },
+  { route, match, componentData, isPreview, h, requestParams },
   cache,
   cacheKey
 ) => {
@@ -47,7 +47,8 @@ const renderSuccessTree = async (
     Component: route.component,
     routeOptions: route.options,
     match,
-    componentData
+    componentData,
+    requestParams
   })
   const response = h
     .response(responseString)
@@ -94,6 +95,8 @@ export default ({ server, config }) => {
           .type('text/html')
           .code(200)
       }
+
+      const requestParams = request.query
 
       // Don't even import react-router any more, but backwards compatible
       // With the exception of optional params: (:thing) becomes :thing?
@@ -178,7 +181,8 @@ export default ({ server, config }) => {
           match,
           componentData,
           isPreview,
-          h
+          h,
+          requestParams
         },
         cache,
         cacheKey

--- a/src/server/render/default-document/index.js
+++ b/src/server/render/default-document/index.js
@@ -4,13 +4,14 @@ import path from 'path'
 
 import stringifyEscapeScript from '../../utilities/stringify-escape-script'
 
-const getBootstrapData = ({ bootstrapData, ids }) => (
+const getBootstrapData = ({ bootstrapData, ids, _tapestryData }) => (
   <script
     type="text/javascript"
     dangerouslySetInnerHTML={{
       __html: `window.__TAPESTRY_DATA__ = { appData: ${stringifyEscapeScript(
         bootstrapData
-      )}, ids: ${JSON.stringify(ids)} }`
+      )}, ids: ${JSON.stringify(ids)},
+      _tapestry: ${stringifyEscapeScript(_tapestryData)} }`
     }}
   />
 )
@@ -37,6 +38,7 @@ const DefaultDocument = ({
   ids,
   head,
   bootstrapData,
+  _tapestryData,
   loadableState
 }) => (
   <html lang="en" {...head.htmlAttributes.toComponent()}>
@@ -52,7 +54,7 @@ const DefaultDocument = ({
     <body>
       <div id="root" dangerouslySetInnerHTML={{ __html: html }} />
       {loadableState.getScriptElement()}
-      {getBootstrapData({ bootstrapData, ids })}
+      {getBootstrapData({ bootstrapData, ids, _tapestryData })}
       {getJavascriptBundles()}
     </body>
   </html>

--- a/src/server/render/tree-to-html.js
+++ b/src/server/render/tree-to-html.js
@@ -8,9 +8,16 @@ export default async ({
   routeOptions = {},
   match,
   componentData,
-  requestParams
+  queryParams
 }) => {
-  const app = <Component {...match} {...componentData} />
+  const bootstrapData = {
+    ...componentData,
+    requestData: {
+      ...match,
+      queryParams
+    }
+  }
+  const app = <Component {...componentData} />
   const htmlString = renderToString(app)
   const loadableState = await getLoadableState(app)
   // { html, css, ids }
@@ -26,10 +33,7 @@ export default async ({
   const renderData = {
     ...styleData,
     head: helmet,
-    bootstrapData: {
-      ...componentData,
-      requestParams
-    },
+    bootstrapData,
     loadableState
   }
   let Document =

--- a/src/server/render/tree-to-html.js
+++ b/src/server/render/tree-to-html.js
@@ -10,15 +10,14 @@ export default async ({
   componentData,
   queryParams
 }) => {
-  const bootstrapData = {
-    ...componentData,
+  const _tapestryData = {
     requestData: {
       ...match,
       queryParams
     }
   }
   // create html string from target component
-  const app = <Component {...bootstrapData} />
+  const app = <Component {...componentData} {..._tapestryData} />
   const htmlString = renderToString(app)
   // get app loading state
   const loadableState = await getLoadableState(app)
@@ -35,7 +34,8 @@ export default async ({
   const renderData = {
     ...styleData,
     head: helmet,
-    bootstrapData,
+    bootstrapData: componentData,
+    _tapestryData,
     loadableState
   }
   let Document =

--- a/src/server/render/tree-to-html.js
+++ b/src/server/render/tree-to-html.js
@@ -17,7 +17,7 @@ export default async ({
     }
   }
   // create html string from target component
-  const app = <Component {...componentData} {..._tapestryData} />
+  const app = <Component {...componentData} _tapestry={_tapestryData} />
   const htmlString = renderToString(app)
   // get app loading state
   const loadableState = await getLoadableState(app)

--- a/src/server/render/tree-to-html.js
+++ b/src/server/render/tree-to-html.js
@@ -7,7 +7,8 @@ export default async ({
   Component,
   routeOptions = {},
   match,
-  componentData
+  componentData,
+  requestParams
 }) => {
   const app = <Component {...match} {...componentData} />
   const htmlString = renderToString(app)
@@ -25,7 +26,10 @@ export default async ({
   const renderData = {
     ...styleData,
     head: helmet,
-    bootstrapData: componentData,
+    bootstrapData: {
+      ...componentData,
+      requestParams
+    },
     loadableState
   }
   let Document =

--- a/src/server/render/tree-to-html.js
+++ b/src/server/render/tree-to-html.js
@@ -17,12 +17,14 @@ export default async ({
       queryParams
     }
   }
-  const app = <Component {...componentData} />
+  // create html string from target component
+  const app = <Component {...bootstrapData} />
   const htmlString = renderToString(app)
+  // get app loading state
   const loadableState = await getLoadableState(app)
   // { html, css, ids }
   let styleData = {}
-  // extract CSS from either Glamor or Emotion
+  // extract html, css and ids from either Glamor or Emotion
   if (process.env.CSS_PLUGIN === 'emotion') {
     styleData = require('emotion-server').extractCritical(htmlString)
   } else {

--- a/test/server/document.test.js
+++ b/test/server/document.test.js
@@ -11,6 +11,16 @@ import styled from 'react-emotion'
 import dataPosts from '../mocks/posts.json'
 import Server, { registerPlugins } from '../../src/server'
 
+const prepareJson = data => {
+  const str = JSON.stringify(data)
+    .replace(/\//g, '\\/')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+
+  // Remove last '}' to make string matching logic more forgiving
+  return str.substring(0, str.length - 1)
+}
+
 describe('Document contents', () => {
   const publicFilePath = path.resolve(process.cwd(), 'public', 'test.txt')
   let server = null
@@ -112,13 +122,11 @@ describe('Document contents', () => {
   it('Contains correct Bootstrap data', done => {
     request.get(uri, (err, res, body) => {
       expect(body).to.contain(
-        `window.__TAPESTRY_DATA__ = { appData: {"data":${JSON.stringify(
+        `window.__TAPESTRY_DATA__ = { appData: {"data":${prepareJson(
           dataPosts.data
-        )
-          .replace(/\//g, '\\/')
-          .replace(/\u2028/g, '\\u2028')
-          .replace(/\u2029/g, '\\u2029')}}, ids: ["vg9k2b"] }`
+        )}`
       )
+      expect(body).to.contain('ids: ["vg9k2b"]')
       done()
     })
   })
@@ -169,10 +177,12 @@ describe('Document contents', () => {
 
   it('Passes correct data to custom document', done => {
     request.get(`${uri}/custom-document/with-data`, (err, res, body) => {
+      const str = JSON.stringify(dataPosts.data)
+
       expect(body).to.contain('Custom Title')
       expect(body).to.contain('Custom HTML')
       expect(body).to.contain(
-        `const test = {"data":${JSON.stringify(dataPosts.data)}}`
+        `const test = {"data":${str.substring(0, str.length - 1)}`
       )
       expect(body).to.contain('{font-size:13px;}')
       done()

--- a/test/server/document.test.js
+++ b/test/server/document.test.js
@@ -11,16 +11,6 @@ import styled from 'react-emotion'
 import dataPosts from '../mocks/posts.json'
 import Server, { registerPlugins } from '../../src/server'
 
-const prepareJson = data => {
-  const str = JSON.stringify(data)
-    .replace(/\//g, '\\/')
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029')
-
-  // Remove last '}' to make string matching logic more forgiving
-  return str.substring(0, str.length - 1)
-}
-
 describe('Document contents', () => {
   const publicFilePath = path.resolve(process.cwd(), 'public', 'test.txt')
   let server = null
@@ -122,9 +112,12 @@ describe('Document contents', () => {
   it('Contains correct Bootstrap data', done => {
     request.get(uri, (err, res, body) => {
       expect(body).to.contain(
-        `window.__TAPESTRY_DATA__ = { appData: {"data":${prepareJson(
+        `window.__TAPESTRY_DATA__ = { appData: {"data":${JSON.stringify(
           dataPosts.data
-        )}`
+        )
+          .replace(/\//g, '\\/')
+          .replace(/\u2028/g, '\\u2028')
+          .replace(/\u2029/g, '\\u2029')}}`
       )
       expect(body).to.contain('ids: ["vg9k2b"]')
       done()
@@ -177,12 +170,10 @@ describe('Document contents', () => {
 
   it('Passes correct data to custom document', done => {
     request.get(`${uri}/custom-document/with-data`, (err, res, body) => {
-      const str = JSON.stringify(dataPosts.data)
-
       expect(body).to.contain('Custom Title')
       expect(body).to.contain('Custom HTML')
       expect(body).to.contain(
-        `const test = {"data":${str.substring(0, str.length - 1)}`
+        `const test = {"data":${JSON.stringify(dataPosts.data)}}`
       )
       expect(body).to.contain('{font-size:13px;}')
       done()

--- a/test/server/preview.test.js
+++ b/test/server/preview.test.js
@@ -7,11 +7,28 @@ import CacheManager from '../../src/server/utilities/cache-manager'
 import Server from '../../src/server'
 import dataPost from '../mocks/post.json'
 
-const prepareJson = data =>
-  JSON.stringify(data)
+const createRequestData = request => {
+  // console.log('> request', request)
+  return {
+    requestData: {
+      isExact: true,
+      params: {},
+      path: '',
+      queryParams: {},
+      url: ''
+    }
+  }
+}
+
+const prepareJson = data => {
+  const str = JSON.stringify(data)
     .replace(/\//g, '\\/')
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029')
+
+  // Remove last '}' to make string matching logic more forgiving
+  return str.substring(0, str.length - 1)
+}
 
 describe('Handling preview requests', () => {
   let server = null
@@ -52,7 +69,7 @@ describe('Handling preview requests', () => {
     request.get(
       `${uri}/dynamic-string-endpoint/preview-test?tapestry_hash=hash&p=10`,
       (err, res, body) => {
-        expect(body).to.contain(prepareJson(dataPost))
+        expect(body).to.have.string(prepareJson(dataPost))
         done()
       }
     )

--- a/test/server/preview.test.js
+++ b/test/server/preview.test.js
@@ -7,19 +7,6 @@ import CacheManager from '../../src/server/utilities/cache-manager'
 import Server from '../../src/server'
 import dataPost from '../mocks/post.json'
 
-const createRequestData = request => {
-  // console.log('> request', request)
-  return {
-    requestData: {
-      isExact: true,
-      params: {},
-      path: '',
-      queryParams: {},
-      url: ''
-    }
-  }
-}
-
 const prepareJson = data => {
   const str = JSON.stringify(data)
     .replace(/\//g, '\\/')

--- a/test/server/preview.test.js
+++ b/test/server/preview.test.js
@@ -7,15 +7,11 @@ import CacheManager from '../../src/server/utilities/cache-manager'
 import Server from '../../src/server'
 import dataPost from '../mocks/post.json'
 
-const prepareJson = data => {
-  const str = JSON.stringify(data)
+const prepareJson = data =>
+  JSON.stringify(data)
     .replace(/\//g, '\\/')
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029')
-
-  // Remove last '}' to make string matching logic more forgiving
-  return str.substring(0, str.length - 1)
-}
 
 describe('Handling preview requests', () => {
   let server = null
@@ -56,7 +52,7 @@ describe('Handling preview requests', () => {
     request.get(
       `${uri}/dynamic-string-endpoint/preview-test?tapestry_hash=hash&p=10`,
       (err, res, body) => {
-        expect(body).to.have.string(prepareJson(dataPost))
+        expect(body).to.contain(prepareJson(dataPost))
         done()
       }
     )

--- a/test/server/routing.test.js
+++ b/test/server/routing.test.js
@@ -9,15 +9,11 @@ import dataPost from '../mocks/post.json'
 import dataPages from '../mocks/pages.json'
 import dataPosts from '../mocks/posts.json'
 
-const prepareJson = data => {
-  const str = JSON.stringify(data)
+const prepareJson = data =>
+  JSON.stringify(data)
     .replace(/\//g, '\\/')
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029')
-
-  // Remove last '}' to make string matching logic more forgiving
-  return str.substring(0, str.length - 1)
-}
 
 describe('Handling custom static routes', () => {
   let server = null

--- a/test/server/routing.test.js
+++ b/test/server/routing.test.js
@@ -26,7 +26,9 @@ describe('Handling custom static routes', () => {
       },
       {
         path: '/static-route/:custom',
-        component: props => <p>Param: {props.requestData.params.custom}</p>
+        component: props => (
+          <p>Param: {props._tapestry.requestData.params.custom}</p>
+        )
       }
     ],
     siteUrl: 'http://routing-dummy.api'

--- a/test/server/routing.test.js
+++ b/test/server/routing.test.js
@@ -9,11 +9,15 @@ import dataPost from '../mocks/post.json'
 import dataPages from '../mocks/pages.json'
 import dataPosts from '../mocks/posts.json'
 
-const prepareJson = data =>
-  JSON.stringify(data)
+const prepareJson = data => {
+  const str = JSON.stringify(data)
     .replace(/\//g, '\\/')
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029')
+
+  // Remove last '}' to make string matching logic more forgiving
+  return str.substring(0, str.length - 1)
+}
 
 describe('Handling custom static routes', () => {
   let server = null
@@ -26,7 +30,7 @@ describe('Handling custom static routes', () => {
       },
       {
         path: '/static-route/:custom',
-        component: props => <p>Param: {props.params.custom}</p>
+        component: props => <p>Param: {props.requestData.params.custom}</p>
       }
     ],
     siteUrl: 'http://routing-dummy.api'


### PR DESCRIPTION
### What have I done
As part of the task for removing 3rd party tracking scripts on previews, I've added the `_tapestry` object to `window.__TAPESTRY_DATA__` which contains the following:

```
{
  "requestData": {
    "path": "/:category/:subcategory?/:slug/:id",
    "url": "/life/heathers-tv-reboot-dropped-paramount-america-school-shootings-films-hollywood/210276",
    "isExact": true,
    "params": {
      "category": "life",
      "slug": "heathers-tv-reboot-dropped-paramount-america-school-shootings-films-hollywood",
      "id": "210276"
    },
    "queryParams": {
      "tapestry_hash": "615e29e009eb95bf1a90bcb219fe6b46a38203d4",
      "p": "210276"
    }
  }
}
```
So we now have access to the `tapestry_hash` query param to check for on the client.