### PR TITLE
Remove matchRoutes from client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# 1.4.1 (08-06-2018)
+
+* Removed `matchRoutes` helper from client bundle
+
 # 1.4.0 (08-06-2018)
 
 * Changed schema of `window.__TAPESTRY_DATA__`. Now includes request data and params. This is means that where previously you'd access `props.params` in the top level component, you'll now use `props._tapestry.requestData.params`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { hot } from 'react-hot-loader'
 
 import prepareAppRoutes from '../server/routing/prepare-app-routes'
-import matchRoutes from '../server/routing/match-routes'
 import buildErrorView from '../server/render/error-view'
 
 const log = (msg, data) =>
@@ -10,17 +9,20 @@ const log = (msg, data) =>
 
 const Root = config => {
   log(`Application data`, window.__TAPESTRY_DATA__)
+
   if (window.__TAPESTRY_DATA__.appData.code === 404) {
     const Component = buildErrorView({ config, missing: false })
     return <Component {...window.__TAPESTRY_DATA__.appData} />
   }
-  const { route, match } = matchRoutes(
-    prepareAppRoutes(config),
-    window.location.pathname
-  )
-  log('Matched route', { route, match })
+
+  const routes = prepareAppRoutes(config)
+  const path = window.__TAPESTRY_DATA__._tapestry.requestData.path
+
+  // We will only ever return the first route, even if multiple are matched
+  const Component = routes.filter(route => route.path === path)[0].component
+
   return (
-    <route.component
+    <Component
       {...window.__TAPESTRY_DATA__.appData}
       _tapestry={window.__TAPESTRY_DATA__._tapestry}
     />

--- a/src/server/routing/default-routes.js
+++ b/src/server/routing/default-routes.js
@@ -1,5 +1,5 @@
 // array of routes supplied with Tapestry
-export default ({ FrontPage, Post, Page, Category }) => [
+export default ({ FrontPage, Post, Page, Category } = {}) => [
   {
     path: '/',
     component: FrontPage,


### PR DESCRIPTION
#### What have I done
- Removed `matchRoutes` helper from client bundle
- Added a default object argument to `default-routes` for safety

#### Tests
Tests are passing
Confirmed expected behaviour in browser