### PR TITLE
Fix unreliable server-side hot reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# 1.4.3 (12-06-2018)
+
+* Fixed server hot reloading
+
 # 1.4.2 (10-06-2018)
 
 * Fixed Loadable Components regression in 1.4.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
 # Tapestry Lite
+We must write more documentation!
+
 
 ## Installation
 

--- a/src/config/hot-server.js
+++ b/src/config/hot-server.js
@@ -1,0 +1,13 @@
+import Server, { registerPlugins } from '../server'
+import appConfig from './config-proxy'
+
+const createNewServerProxy = function() {
+  return new Server({ config: appConfig })
+}
+
+const registerPluginProxy = async server => {
+  // Register plugins
+  return registerPlugins({ config: appConfig, server: server })
+}
+
+export { registerPluginProxy, createNewServerProxy }

--- a/src/config/hot.js
+++ b/src/config/hot.js
@@ -1,4 +1,5 @@
 import { registerPluginProxy, createNewServerProxy } from './hot-server'
+import { notify } from '../server/utilities/logger'
 
 let currentApp = createNewServerProxy()
 
@@ -8,11 +9,13 @@ if (module.hot) {
     currentApp = createNewServerProxy()
     await registerPluginProxy(currentApp)
     await currentApp.start()
-    console.log('🔁  HMR Reloading `./hot-server`...')
+    notify('🔁  HMR Reloading `./hot-server`...')
   })
-  console.info('✅  Server-side HMR Enabled!')
+  notify('✅  Server-side HMR Enabled!')
 }
 
 registerPluginProxy(currentApp).then(() => {
   currentApp.start()
 })
+
+notify(`Server started at: ${currentApp.info.uri}\n`)

--- a/src/config/hot.js
+++ b/src/config/hot.js
@@ -1,34 +1,18 @@
-import Server, { registerPlugins } from '../server'
-import appConfig from './config-proxy'
-import { log, notify } from '../server/utilities/logger'
+import { registerPluginProxy, createNewServerProxy } from './hot-server'
 
-let currentApp
+let currentApp = createNewServerProxy()
 
-const run = async () => {
-  try {
-    currentApp = new Server({ config: appConfig })
-    // Register plugins
-    await registerPlugins({ config: appConfig, server: currentApp })
-    // Start server
+if (module.hot) {
+  module.hot.accept('./hot-server', async function() {
+    await currentApp.stop({ timeout: 0 })
+    currentApp = createNewServerProxy()
+    await registerPluginProxy(currentApp)
     await currentApp.start()
-    if (module.hot) {
-      module.hot.addStatusHandler(async status => {
-        if (status === 'ready') {
-          await currentApp.stop({ timeout: 0 })
-          currentApp = new Server({ config: require('./config-proxy').default })
-          // Re-register plugins
-          await registerPlugins({
-            config: require('./config-proxy').default,
-            server: currentApp
-          })
-          await currentApp.start()
-        }
-      })
-    }
-    notify(`Server started at: ${currentApp.info.uri}\n`)
-  } catch (e) {
-    log.error(e)
-  }
+    console.log('🔁  HMR Reloading `./hot-server`...')
+  })
+  console.info('✅  Server-side HMR Enabled!')
 }
 
-run()
+registerPluginProxy(currentApp).then(() => {
+  currentApp.start()
+})


### PR DESCRIPTION
A couple of the team had mentioned the "not accepted" bug happening on all the projects.
 
Steps to reproduce were:
 - Change a jsx file (not styles)
 - In the console you'd get a hot-reload error talking about a module not accepted
 - Prior to the recent ["verbosity" change](https://github.com/shortlist-digital/tapestry-lite/commit/d44703b1de2f226687bfb85ac3f6dd42d7474fee) in the webpack configs, this failure would overwrite a terminal output message from the _client_ webpack, saying that the module _was_ accepted on the client, and that compilation was successfu
  - After removing the terminal "clear" from webpack, it was then evident that the client was compiling and the server was not - this narrowed it down to a server configuration problem, rather than anything wrong with our components.

I'm not expert enough in this, but this was my thought process.

 - React Hot Reloader depends on these "proxy" pointers between files, components, functions etc. 
 - It was odd that component reloading was fine on the client but not on the server
 - We were using the "ready" status handler callback instead of generic "accept" callback on the server, this meant we weren't catching a load of different hot module states. [Webpack module hot status list](https://webpack.js.org/api/hot-module-replacement/#addstatushandler)

I've added another proxy file for the server, and reverted to the generic `module.hot.accept` callback, I've tested this with a few legacy projects and SSR hot reloading of the components is working the expected way again.

## To test:
`cd ~/your-local/tapestry-lite && yarn link`

`cd ~/test-project && yarn link tapestry-lite`

You can now run your project, and then hot reload components with JavaScript turned off! Woo.