### PR TITLE
Incorrect asset chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# 1.4.5 (22-06-2018)
+
+* Fix oddly formatted chunks (within assets.json) adding malformed script references to the page
+
 # 1.4.4 (20-06-2018)
 
 * Boost initial boot time with improved Webpack config creation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/src/config/createWebpackConfig.js
+++ b/src/config/createWebpackConfig.js
@@ -169,8 +169,9 @@ module.exports = (target = 'node') => {
       plugins: [
         new StatsPlugin('../stats.json'),
         new AssetsPlugin({
+          filename: 'assets.json',
           path: paths.appBuild,
-          filename: 'assets.json'
+          prettyPrint: true
         })
       ],
       optimization: {

--- a/src/server/render/default-document/index.js
+++ b/src/server/render/default-document/index.js
@@ -26,9 +26,9 @@ const getJavascriptBundles = () => {
   if (process.env.NODE_ENV === 'production') {
     const assetsPath = path.resolve(process.cwd(), '.tapestry', 'assets.json')
     const assets = fs.readJsonSync(assetsPath)
-    return Object.values(assets).map(({ js }, index) => (
-      <script key={index} src={js} />
-    ))
+    return Object.keys(assets)
+      .filter(Boolean)
+      .map((key, index) => <script key={index} src={assets[key].js} />)
   }
 }
 


### PR DESCRIPTION
We couldn't reproduce this issue locally but this will protect us against it happening on Heroku again.

`assets.json` on Heroku included all other chunks (split js, css files, json) as well as the entry files(client, vendor), whereas locally (and previously on Heroku 🤔) it has always _only_ included the entry files.