### PR TITLE
Feature/proxy separate domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# 1.5.0 (04-07-2018)
+
+* Added support for proxies from a different domain
+
 # 1.4.5 (22-06-2018)
 
 * Fix oddly formatted chunks (within assets.json) adding malformed script references to the page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/src/server/handlers/proxy.js
+++ b/src/server/handlers/proxy.js
@@ -1,14 +1,32 @@
+import isPlainObject from 'lodash.isplainobject'
+
 export default ({ server, config }) => {
-  if (!config.proxyPaths) return
-  config.proxyPaths.map(path => {
+  if (!Array.isArray(config.proxyPaths)) return
+
+  const route = ({ from, to }) =>
     server.route({
       method: 'GET',
-      path: `${path}`,
-      handler: (request, h) => {
-        return h.proxy({
-          uri: config.siteUrl + path
-        })
-      }
+      path: from,
+      handler: (req, h) => h.proxy({ uri: to })
     })
+
+  config.proxyPaths.map(path => {
+    // support an object syntax to proxy to a different domain
+    // { '/app/something/{feed}': 'https://www.something.com/somewhere/{feed}' }
+    if (isPlainObject(path)) {
+      // try to keep the proxy objects separate
+      // {'': ''}, {'': ''}
+      if (Object.keys(path).length > 1) {
+        console.error('Proxy object contains more than a single key/value pair')
+        return
+      }
+      // as object only has a single key we can grab the key[0] and value[0]
+      return route({
+        from: Object.keys(path)[0],
+        to: Object.values(path)[0]
+      })
+    }
+    // otherwise treat the string as a traditional proxy to the site URL
+    return route({ from: path, to: config.siteUrl + path })
   })
 }

--- a/test/server/proxies.test.js
+++ b/test/server/proxies.test.js
@@ -46,7 +46,7 @@ describe('Handling wildcard proxies', () => {
   let proxyPath = '/sitemap/{sitemapId}'
   let proxyContents = 'Test file'
   let config = {
-    proxyPaths: [proxyPath],
+    proxyPaths: [proxyPath, { '/test': 'http://test.proxy/test.xml' }],
     siteUrl: 'http://dummy.api',
     components: {}
   }
@@ -57,6 +57,9 @@ describe('Handling wildcard proxies', () => {
       .get('/sitemap/test.xml')
       .reply(200, proxyContents)
       .get('/sitemap/different-id.xml')
+      .reply(200, proxyContents)
+    nock('http://test.proxy')
+      .get('/test.xml')
       .reply(200, proxyContents)
     // boot tapestry server
     server = new Server({ config })
@@ -76,6 +79,13 @@ describe('Handling wildcard proxies', () => {
 
   it('Proxy should return correct content from test b', done => {
     request.get(uri + '/sitemap/different-id.xml', (err, res, body) => {
+      expect(body).to.contain(proxyContents)
+      done()
+    })
+  })
+
+  it('Proxy should return correct content from object syntax', done => {
+    request.get(uri + '/test', (err, res, body) => {
       expect(body).to.contain(proxyContents)
       done()
     })

--- a/test/server/proxies.test.js
+++ b/test/server/proxies.test.js
@@ -46,7 +46,10 @@ describe('Handling wildcard proxies', () => {
   let proxyPath = '/sitemap/{sitemapId}'
   let proxyContents = 'Test file'
   let config = {
-    proxyPaths: [proxyPath, { '/test': 'http://test.proxy/test.xml' }],
+    proxyPaths: [
+      proxyPath,
+      { '/test/{something}': 'http://test.proxy/test/hello.xml' }
+    ],
     siteUrl: 'http://dummy.api',
     components: {}
   }
@@ -59,7 +62,7 @@ describe('Handling wildcard proxies', () => {
       .get('/sitemap/different-id.xml')
       .reply(200, proxyContents)
     nock('http://test.proxy')
-      .get('/test.xml')
+      .get('/test/hello.xml')
       .reply(200, proxyContents)
     // boot tapestry server
     server = new Server({ config })
@@ -85,7 +88,7 @@ describe('Handling wildcard proxies', () => {
   })
 
   it('Proxy should return correct content from object syntax', done => {
-    request.get(uri + '/test', (err, res, body) => {
+    request.get(uri + '/test/hello', (err, res, body) => {
       expect(body).to.contain(proxyContents)
       done()
     })


### PR DESCRIPTION
Support object syntax for proxies on a different domain e.g.

```js
{
  proxyPaths: ['/robots.txt', { '/from': 'https://www.somewhere.com/to' }]
}
```