### PR TITLE
Feature/proxy test path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# 1.5.1 (05-07-2018)
+
+* Test for falsey values when setting proxies
+
 # 1.5.0 (04-07-2018)
 
 * Added support for proxies from a different domain

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/src/server/handlers/proxy.js
+++ b/src/server/handlers/proxy.js
@@ -27,6 +27,8 @@ export default ({ server, config }) => {
       })
     }
     // otherwise treat the string as a traditional proxy to the site URL
-    return route({ from: path, to: config.siteUrl + path })
+    if (path) {
+      return route({ from: path, to: config.siteUrl + path })
+    }
   })
 }


### PR DESCRIPTION
We should check that the path exists before passing to h2o2.

Allows us to `['/robots.txt', ENV && '/ads.txt']`