### PR TITLE
Webpack custom configuration check

### DIFF
--- a/src/config/createWebpackConfig.js
+++ b/src/config/createWebpackConfig.js
@@ -202,7 +202,11 @@ module.exports = (target = 'node') => {
 
   // use custom webpack config
   if (fs.existsSync(paths.appWebpackConfig)) {
-    config = require(paths.appWebpackConfig)(config, {}, webpack)
+    let customConfig = require(paths.appWebpackConfig)
+    config =
+      typeof customConfig === 'function'
+        ? customConfig(config, {}, webpack)
+        : customConfig.default(config, {}, webpack)
   }
 
   return config

--- a/test/fixtures/build-with-custom-webpack/webpack.config.js
+++ b/test/fixtures/build-with-custom-webpack/webpack.config.js
@@ -1,6 +1,8 @@
 const path = require('path')
 
-module.exports = (config, opts, webpack) => {
-  config.resolve.alias.components = path.resolve(__dirname, 'components')
-  return config
+module.exports = {
+  default: (config, opts, webpack) => {
+    config.resolve.alias.components = path.resolve(__dirname, 'components')
+    return config
+  }
 }


### PR DESCRIPTION
Added support for an object export from a custom webpack config.

As a result, module exports can be objects:
```
module.exports = {
  default: () => {
  }
}
```
or functions:
```
module.exports = () => {}
```