### PR TITLE
Feature / Broadcast server compilation events to the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+# 2.3.0 (11-12-2018)
+
+- Broadcast websocket events for server compilation to the client
+
 # 2.2.0 (11-9-2018)
 
-* React Error Overlay for browser error notification in dev
-* Noisier terminal output during dev
+- React Error Overlay for browser error notification in dev
+- Noisier terminal output during dev
 
 # 2.1.0 (10-11-2018)
-* Added `customDoctype` option to `routeOptions`. If a value is passed it will override the default one`<!doctype html>`
+
+- Added `customDoctype` option to `routeOptions`. If a value is passed it will override the default one`<!doctype html>`
 
 # 2.0.0 (11-10-2018)
 

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -17,4 +17,17 @@ serverCompiler.watch({ quiet: false }, (err, stats) => {
   }
 })
 
+serverCompiler.hooks.compile.tap(
+  'Tapestry Lite Sever Compile Starting',
+  stats => {
+    clientDevServer.sockWrite(clientDevServer.sockets, 'server-compile-starts')
+    console.log('Emitted server compile end message', stats)
+  }
+)
+
+serverCompiler.hooks.done.tap('Tapestry Lite Server Compile Complete', () => {
+  clientDevServer.sockWrite(clientDevServer.sockets, 'server-compile-ends')
+  console.log('Emitted server compile start message')
+})
+
 clientDevServer.listen(4001, err => console.error(err))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {


### PR DESCRIPTION
During development, the client will receive websocket events indicating the beginning and end of a server compile.

This will allow for the client to re-render SSR iFrame and embeds without a race condition, as well as providing a route for developing UI that could indicate server compile status

NB - This does not affect the client scripts at all - to utilise these events you will need to hook into websockets natively or via libary like sock.js

Example from Create React App here:

https://github.com/facebook/create-react-app/blob/4562ab6fd80c3e18858b3a9a3828810944c35e36/packages/react-dev-utils/webpackHotDevClient.js#L60