### PR TITLE
Fix: Preview cache

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -10,12 +10,7 @@ import Root from './root'
 
 // If page is a WP preview, remove any tapestry related querystring data
 // This runs on the client only so it won't affect loading preview data
-// Added check for the history API for compatibility with other browsers
-if (
-  window.location.search.indexOf('tapestry_hash') > -1 &&
-  window.history &&
-  window.history.replaceState
-) {
+if (window.location.search.indexOf('tapestry_hash') > -1) {
   window.history.replaceState(
     {},
     document.title,

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -8,6 +8,23 @@ import { loadComponents } from 'loadable-components'
 import config from '../config/config-proxy'
 import Root from './root'
 
+// If page is a WP preview, remove any tapestry related querystring data
+// This runs on the client only so it won't affect loading preview data
+// Added check for the history API for compatibility with other browsers
+if (
+  window.location.search.indexOf('tapestry_hash') > -1 &&
+  window.history &&
+  window.history.replaceState
+) {
+  window.history.replaceState(
+    {},
+    document.title,
+    `${window.location.protocol}//${window.location.host}${
+      window.location.pathname
+    }`
+  )
+}
+
 // Hydrate server rendered CSS with either Emotion or Glamor
 if (CSS_PLUGIN === 'emotion')
   require('emotion').hydrate(window.__TAPESTRY_DATA__.ids)

--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -26,7 +26,6 @@ export default ({ server, config }) => {
     handler: async (request, h) => {
       // Set a cache key
       const currentPath = request.url.pathname || '/'
-      const isPreview = Boolean(request.query && request.query.tapestry_hash)
       const cacheKey = normaliseUrlPath(currentPath)
       // Is there cached HTML?
       const cacheObject = await cache.get(cacheKey)
@@ -58,21 +57,13 @@ export default ({ server, config }) => {
         config
       )
 
-      let response = h
+      log.debug(`Setting html in cache: ${chalk.green(cacheKey)}`)
+      cache.set(cacheKey, { responseString, status })
+
+      return h
         .response(responseString)
         .type('text/html')
         .code(status)
-
-      if (!isPreview) {
-        log.debug(`Setting html in cache: ${chalk.green(cacheKey)}`)
-        cache.set(cacheKey, { responseString, status })
-      }
-
-      if (isPreview) {
-        response.header('cache-control', 'no-cache')
-      }
-
-      return response
     }
   })
 }


### PR DESCRIPTION
- Set cache for all preview links, rely on Tapestry Wordpress Plugin to produce unique hash per content update
- Remove tapestry query string data from URL on load