### PR TITLE
Fix: Normalised path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Set cache for all preview links, rely on Tapestry Wordpress Plugin to produce unique hash per update
 - Remove tapestry query string data from URL on load
+- Fix normalised path issue
 
 # 2.3.4 (08-02-2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+# 3.0.0 (11-02-2019)
+
+- Set cache for all preview links, rely on Tapestry Wordpress Plugin to produce unique hash per update
+- Remove tapestry query string data from URL on load
+
 # 2.3.4 (08-02-2019)
 
 - Pass through headers for proxies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "2.3.4",
+  "version": "3.0.0",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -1,8 +1,5 @@
 import chalk from 'chalk'
 
-import prepareAppRoutes from '../routing/prepare-app-routes'
-import matchRoutes from '../routing/match-routes'
-
 import normaliseUrlPath from '../utilities/normalise-url-path'
 import CacheManager from '../utilities/cache-manager'
 import { log } from '../utilities/logger'
@@ -12,7 +9,7 @@ import tapestryRender from '../render/tapestry-render'
 export default ({ server, config }) => {
   const cacheManager = new CacheManager()
   const cache = cacheManager.createCache('html')
-  const routes = prepareAppRoutes(config)
+
   server.route({
     options: {
       cache: {
@@ -39,22 +36,9 @@ export default ({ server, config }) => {
           .code(cacheObject.status)
       }
 
-      const queryParams = request.query
-
-      // Don't even import react-router any more, but backwards compatible
-      // With the exception of optional params: (:thing) becomes :thing?
-      // Match Routes
-      // this should only have one route as we force "exact" on each route
-      // How would we error out if two routes match here? "Ambigous routes detected?" maybe earlier in app
-      const { route } = matchRoutes(routes, request.url.pathname)
-
-      log.debug(`Matched route ${chalk.green(route.path)}`)
-
-      const requestPath = currentPath
-      const requestQuery = queryParams
       const { responseString, status } = await tapestryRender(
-        requestPath,
-        requestQuery,
+        currentPath,
+        request.query,
         config
       )
 

--- a/src/server/render/tapestry-render.js
+++ b/src/server/render/tapestry-render.js
@@ -11,24 +11,16 @@ import renderSuccessTree from './render-success-tree'
 import renderErrorTree from './render-error-tree'
 
 import baseUrlResolver from '../utilities/base-url-resolver'
-import normaliseUrlPath from '../utilities/normalise-url-path'
 import { log } from '../utilities/logger'
 
 export default async (requestPath, requestQuery, config) => {
-  const routes = prepareAppRoutes(config)
-  const currentPath = requestPath || ''
-  //const isPreview = Boolean(request.query && request.query.tapestry_hash)
-  const normalisedPath = `/${normaliseUrlPath(currentPath)}`
-
-  const queryParams = requestQuery
-
   // Don't even import react-router any more, but backwards compatible
   // With the exception of optional params: (:thing) becomes :thing?
   // Match Routes
   // this should only have one route as we force "exact" on each route
   // How would we error out if two routes match here? "Ambigous routes detected?" maybe earlier in app
-  const { route, match } = matchRoutes(routes, normalisedPath)
-
+  const routes = prepareAppRoutes(config)
+  const { route, match } = matchRoutes(routes, requestPath)
   log.debug(`Matched route ${chalk.green(route.path)}`)
   // This needs tidying
   // If there's a branch of the route config, we have a route
@@ -45,9 +37,9 @@ export default async (requestPath, requestQuery, config) => {
     // Start to try and fetch data
     const multidata = await fetchFromEndpointConfig({
       endpointConfig: route.endpoint,
-      baseUrl: baseUrlResolver(config, queryParams),
+      baseUrl: baseUrlResolver(config, requestQuery),
       params: match.params,
-      queryParams
+      queryParams: requestQuery
     })
     componentData = normalizeApiResponse(multidata, route)
   }
@@ -111,7 +103,7 @@ export default async (requestPath, requestQuery, config) => {
     route,
     match,
     componentData,
-    queryParams
+    queryParams: requestQuery
   })
 
   return {


### PR DESCRIPTION
Removed a bunch of unnecessary code from `dynamic` and removed the duplicated `normalisedPath()` from tapestry-render.

Fixes non-matching path when using `/`