### PR TITLE
Featyre/Serialize cache object for redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# 3.0.2 (14-02-2019)
+
+- Serialize/Deserialize responseObject into cache
+
 # 3.0.1 (13-02-2019)
 
 - Fix potential cache/response issue in dynamic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -25,9 +25,10 @@ export default ({ server, config }) => {
       const currentPath = request.url.pathname || '/'
       const cacheKey = normaliseUrlPath(currentPath)
       // Is there cached HTML?
-      const cacheObject = await cache.get(cacheKey)
+      const cacheString = await cache.get(cacheKey)
       // If there's a cache response, return the response straight away
-      if (cacheObject) {
+      if (cacheString) {
+        const cacheObject = JSON.parse(cacheString)
         log.debug(`Rendering HTML from cache: ${chalk.green(cacheKey)}`)
         return h
           .response(cacheObject.responseString)
@@ -48,7 +49,7 @@ export default ({ server, config }) => {
       // cache _must_ be set after response is created
       // I don't know why
       log.debug(`Setting html in cache: ${chalk.green(cacheKey)}`)
-      cache.set(cacheKey, { responseString, status })
+      cache.set(cacheKey, JSON.stringify({ responseString, status }))
 
       return response
     }

--- a/test/server/cache.test.js
+++ b/test/server/cache.test.js
@@ -148,7 +148,8 @@ describe('Handling cache set/get', () => {
   it('Sets HTML cache items correctly', done => {
     request.get(uri, async (err, res, body) => {
       const cacheHtml = cacheManager.getCache('html')
-      const cacheObject = await cacheHtml.get('/')
+      const cacheString = await cacheHtml.get('/')
+      const cacheObject = JSON.parse(cacheString)
       expect(cacheObject.responseString)
         .to.be.a('string')
         .that.includes('doctype')
@@ -161,7 +162,8 @@ describe('Handling cache set/get', () => {
       `${uri}/2017/12/01/query-test?utm_source=stop-it`,
       async (err, res, body) => {
         const cacheHtml = cacheManager.getCache('html')
-        const shouldCache = await cacheHtml.get('2017/12/01/query-test')
+        const shouldCacheString = await cacheHtml.get('2017/12/01/query-test')
+        const shouldCache = JSON.parse(shouldCacheString)
         const shouldNotCache = await cacheHtml.get(
           '2017/12/01/query-test?utm_source=stop-it'
         )
@@ -177,7 +179,10 @@ describe('Handling cache set/get', () => {
   it('Retrieves HTML cache items correctly', done => {
     const cacheHtml = cacheManager.getCache('html')
     const response = 'test string'
-    cacheHtml.set('2018/01/01/test', { responseString: response, status: 200 })
+    cacheHtml.set(
+      '2018/01/01/test',
+      JSON.stringify({ responseString: response, status: 200 })
+    )
     request.get(`${uri}/2018/01/01/test`, (err, res, body) => {
       expect(body).to.equal(response)
       done()


### PR DESCRIPTION
Redis only supports a type of string (funky list data type not withstanding)

We stringify/parse the cacheObject now in order to fix a rather gigantic bug.

I will raise a PR with the redis plugin - which is where this should be happening.