### PR TITLE
Fix: Error route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+# 4.1.0 (19-02-2019)
+
+- Allow `{ path: '/', error: true }` to return 404
+- Only bundle `missing-view` and `error-view` if PROD
+
 # 4.0.1 (14-02-2019)
 
 - Check if request is preview before returning cached response

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/src/server/render/error-view.js
+++ b/src/server/render/error-view.js
@@ -1,20 +1,14 @@
-import DefaultError from './default-error'
-import MissingView from './missing-view'
-
 export default ({ config = {}, missing = false }) => {
-  // render custom error or default if custom error not declared
-  let ErrorView =
-    config.components && config.components.CustomError
-      ? config.components.CustomError
-      : DefaultError
-  // render missing component only in DEV
-  if (
-    (process.env.NODE_ENV === 'test' ||
-      process.env.NODE_ENV === 'development') &&
-    missing
-  ) {
-    ErrorView = MissingView
+  // always return custom error if declared
+  if (config.components && config.components.CustomError) {
+    return config.components.CustomError
   }
-  // return one of the error views
-  return ErrorView
+  // if _not_ production, return missing view or default tapestry error
+  if (process.env.NODE_ENV !== 'production' && missing) {
+    return missing
+      ? require('./missing-view').default
+      : require('./default-error').default
+  }
+  // otherwise nahp just a nully
+  return () => null
 }

--- a/src/server/render/tapestry-render.js
+++ b/src/server/render/tapestry-render.js
@@ -71,8 +71,6 @@ export default async (requestPath, requestQuery, config) => {
     return errorResponse({ config, route, match })
   }
 
-  // console.log({ errorComponent })
-
   // otherwise build component tree with API data
   const responseString = await renderSuccessTree({
     route,

--- a/src/server/render/tapestry-render.js
+++ b/src/server/render/tapestry-render.js
@@ -6,6 +6,7 @@ import matchRoutes from '../routing/match-routes'
 
 import normalizeApiResponse from '../data-fetching/normalize-api-response'
 import fetchFromEndpointConfig from '../data-fetching/fetch-from-endpoint-config'
+
 import buildErrorView from './error-view'
 import renderSuccessTree from './render-success-tree'
 import renderErrorTree from './render-error-tree'
@@ -13,92 +14,66 @@ import renderErrorTree from './render-error-tree'
 import baseUrlResolver from '../utilities/base-url-resolver'
 import { log } from '../utilities/logger'
 
+const errorResponse = async ({ config, route, match, missing = false }) => {
+  log.debug('Render Error component')
+
+  const errorComponent = buildErrorView({ config, missing })
+
+  const responseString = await renderErrorTree({
+    errorComponent,
+    route,
+    match,
+    componentData: {
+      code: 404,
+      message: 'Not Found'
+    }
+  })
+  return {
+    responseString,
+    status: 404
+  }
+}
+
 export default async (requestPath, requestQuery, config) => {
-  // Don't even import react-router any more, but backwards compatible
-  // With the exception of optional params: (:thing) becomes :thing?
-  // Match Routes
-  // this should only have one route as we force "exact" on each route
-  // How would we error out if two routes match here? "Ambigous routes detected?" maybe earlier in app
-  const routes = prepareAppRoutes(config)
-  const { route, match } = matchRoutes(routes, requestPath)
+  // get matching route and match data
+  const { route, match } = matchRoutes(prepareAppRoutes(config), requestPath)
+  let componentData = {}
+
   log.debug(`Matched route ${chalk.green(route.path)}`)
-  // This needs tidying
-  // If there's a branch of the route config, we have a route
-  // Optimistic default component data for static routes
-  let componentData = {
-    status: 200,
-    message: '200'
+
+  // route has requested an error response
+  // route hasn't configured a component
+  if (route.error || typeof route.component === 'undefined') {
+    log.silly('Render Error component', { route, match })
+    return errorResponse({ config, route, match, missing: true })
   }
 
-  // Set a flag for whether we have a missing component later on
-  const routeComponentUndefined = typeof route.component === 'undefined'
-  // If we have an endpoint
+  // endpoint has been specified, data requested
   if (route.endpoint) {
-    // Start to try and fetch data
-    const multidata = await fetchFromEndpointConfig({
+    const data = await fetchFromEndpointConfig({
       endpointConfig: route.endpoint,
       baseUrl: baseUrlResolver(config, requestQuery),
       params: match.params,
       queryParams: requestQuery
     })
-    componentData = normalizeApiResponse(multidata, route)
-  }
-  if (componentData.code > 299 || routeComponentUndefined) {
-    log.debug(`Render Error component`, {
-      componentData,
-      routeComponentUndefined
-    })
-
-    const errorComponent = buildErrorView({
-      config,
-      missing: routeComponentUndefined
-    })
-
-    const responseString = await renderErrorTree({
-      errorComponent,
-      route,
-      match,
-      componentData
-    })
-
-    return {
-      responseString,
-      status: componentData.status || 404
-    }
+    componentData = normalizeApiResponse(data, route)
   }
 
-  // If our route is the not found route
-  // Overwrite the data
-  const loadedData = componentData.data || componentData
-  if (route.notFoundRoute || (route.endpoint && isEmpty(loadedData))) {
-    log.silly(
-      'Route is "not found" route',
-      route.endpoint,
-      isEmpty(loadedData),
-      componentData,
-      route.notFoundRoute
-    )
-    componentData = {
-      message: 'Not Found',
-      code: 404
-    }
-    const errorComponent = buildErrorView({
-      config,
-      missing: routeComponentUndefined
-    })
-    const responseString = await renderErrorTree({
-      errorComponent,
-      route,
-      match,
-      componentData
-    })
-
-    return {
-      responseString,
-      status: componentData.status || 404
-    }
+  // route hasn't got a match from config.routes
+  // status from API response is not OK
+  // API returns empty response
+  if (
+    route.notFoundRoute ||
+    componentData.code > 299 ||
+    (route.endpoint && isEmpty(componentData.data || componentData))
+  ) {
+    log.silly('Render Error component', { route, match, componentData })
+    return errorResponse({ config, route, match })
   }
 
+  // console.log({ errorComponent })
+
+  // otherwise build component tree with API data
   const responseString = await renderSuccessTree({
     route,
     match,

--- a/test/server/error-view.test.js
+++ b/test/server/error-view.test.js
@@ -35,19 +35,11 @@ describe('Error view rendering', () => {
   afterEach(async () => await server.stop())
 
   it('Show MissingView in DEV if component missing', async () => {
-    server = new Server({config})
+    server = new Server({ config })
     await server.start()
     let res = await r.get(server.info.uri)
     let body = await res.text()
     expect(body).to.contain('Missing component')
-  })
-
-  it('Show DefaultError in PROD if component missing', async () => {
-    server = new Server({config})
-    await server.start()
-    let res = await r.get(server.info.uri)
-    let body = await res.text()
-    expect(body).to.contain('Application Error')
   })
 
   it('Show DefaultError if API 404', async () => {
@@ -116,4 +108,3 @@ describe('Error view rendering', () => {
     expect(body).to.contain('Not Found')
   })
 })
-


### PR DESCRIPTION
Allows the user to pass a route of `{ path: '/error-please', error: true }` to return a 404 and Error view without touching the API.

Also tweaked the error component handling to only return (and bundle) a Tapestry default `missing` or `error` if we're not in production mode.