### PR TITLE
Feature: Base url route option

### DIFF
--- a/src/server/handlers/api.js
+++ b/src/server/handlers/api.js
@@ -1,6 +1,4 @@
 import baseUrlResolver from '../utilities/base-url-resolver'
-import prepareAppRoutes from '../routing/prepare-app-routes'
-import matchRoutes from '../routing/match-routes'
 
 export default ({ server, config }) => {
   server.route({
@@ -15,8 +13,7 @@ export default ({ server, config }) => {
     },
     handler: ({ params, url }, h) => {
       // get matching route and match data
-      const { route } = matchRoutes(prepareAppRoutes(config), url.pathname)
-      const base = baseUrlResolver(config, params.query, route)
+      const base = baseUrlResolver(config)
       return h.proxy({
         uri: `${base}/${params.query}${url.search || ''}`,
         passThrough: true

--- a/src/server/handlers/api.js
+++ b/src/server/handlers/api.js
@@ -1,7 +1,8 @@
 import baseUrlResolver from '../utilities/base-url-resolver'
+import prepareAppRoutes from '../routing/prepare-app-routes'
+import matchRoutes from '../routing/match-routes'
 
 export default ({ server, config }) => {
-  const base = baseUrlResolver(config)
   server.route({
     method: 'GET',
     path: '/api/v1/{query*}',
@@ -12,10 +13,14 @@ export default ({ server, config }) => {
         privacy: 'public'
       }
     },
-    handler: ({ params, url }, h) =>
-      h.proxy({
+    handler: ({ params, url }, h) => {
+      // get matching route and match data
+      const { route } = matchRoutes(prepareAppRoutes(config), url.pathname)
+      const base = baseUrlResolver(config, params.query, route)
+      return h.proxy({
         uri: `${base}/${params.query}${url.search || ''}`,
         passThrough: true
       })
+    }
   })
 }

--- a/src/server/render/tapestry-render.js
+++ b/src/server/render/tapestry-render.js
@@ -68,7 +68,7 @@ export default async (path, query, config) => {
   if (route.endpoint) {
     const data = await fetchFromEndpointConfig({
       endpointConfig: route.endpoint,
-      baseUrl: baseUrlResolver(config, query),
+      baseUrl: baseUrlResolver(config, query, route),
       params: match.params,
       queryParams: query
     })

--- a/src/server/utilities/base-url-resolver.js
+++ b/src/server/utilities/base-url-resolver.js
@@ -1,7 +1,12 @@
 import idx from 'idx'
 import normaliseUrlPath from './normalise-url-path'
 
-export default (config, queryParams) => {
+export default (config, queryParams, route) => {
+  console.log({ config, queryParams, route })
+  // Use baseUrl if passed
+  if (route.options && route.options.baseUrl) {
+    return route.options.baseUrl
+  }
   // Handle preview API path
   if (idx(queryParams, _ => _.tapestry_hash))
     return `${normaliseUrlPath(config.siteUrl)}/wp-json/revision/v1`

--- a/src/server/utilities/base-url-resolver.js
+++ b/src/server/utilities/base-url-resolver.js
@@ -1,17 +1,16 @@
-import idx from 'idx'
 import normaliseUrlPath from './normalise-url-path'
 
-export default (config, queryParams, route) => {
-  console.log({ config, queryParams, route })
+export default (config, query = {}, route) => {
   // Use baseUrl if passed
   if (route.options && route.options.baseUrl) {
     return route.options.baseUrl
   }
   // Handle preview API path
-  if (idx(queryParams, _ => _.tapestry_hash))
+  if (query.tapestry_hash) {
     return `${normaliseUrlPath(config.siteUrl)}/wp-json/revision/v1`
+  }
   // Handle wordpress.com API path
-  if (idx(config, _ => _.options.wordpressDotComHosting)) {
+  if (config.options && config.options.wordpressDotComHosting) {
     // Remove protocol
     const noProtocolSiteUrl = config.siteUrl.replace(/^https?:\/\//i, '')
     return `https://public-api.wordpress.com/wp/v2/sites/${normaliseUrlPath(

--- a/src/server/utilities/base-url-resolver.js
+++ b/src/server/utilities/base-url-resolver.js
@@ -1,6 +1,6 @@
 import normaliseUrlPath from './normalise-url-path'
 
-export default (config, query = {}, route) => {
+export default (config, query = {}, route = {}) => {
   // Use baseUrl if passed
   if (route.options && route.options.baseUrl) {
     return route.options.baseUrl

--- a/test/server/preview.test.js
+++ b/test/server/preview.test.js
@@ -22,6 +22,12 @@ describe('Handling preview requests', () => {
         path: '/dynamic-string-endpoint/:slug',
         endpoint: ({ slug }) => `posts?slug=${slug}`,
         component: () => <p>Custom endpoint</p>
+      },
+      {
+        path: '/custom-base-url/:slug',
+        endpoint: ({ slug }) => `posts?slug=${slug}`,
+        component: () => <p>Custom endpoint</p>,
+        options: { baseUrl: 'https://bloop.com/something' }
       }
     ],
     siteUrl: 'http://preview-dummy.api'
@@ -35,6 +41,9 @@ describe('Handling preview requests', () => {
       .get(
         '/wp-json/revision/v1/posts?slug=preview-test&tapestry_hash=hash&p=10'
       )
+      .reply(200, dataPost)
+    nock('https://bloop.com')
+      .get('/something/posts?slug=preview-test&tapestry_hash=hash&p=10')
       .reply(200, dataPost)
     // boot tapestry server
     process.env.CACHE_MAX_AGE = 60 * 1000
@@ -51,6 +60,16 @@ describe('Handling preview requests', () => {
   it('Preview route renders', done => {
     request.get(
       `${uri}/dynamic-string-endpoint/preview-test?tapestry_hash=hash&p=10`,
+      (err, res, body) => {
+        expect(body).to.contain(prepareJson(dataPost))
+        done()
+      }
+    )
+  })
+
+  it('Custom baseUrl route renders', done => {
+    request.get(
+      `${uri}/custom-base-url/preview-test?tapestry_hash=hash&p=10`,
       (err, res, body) => {
         expect(body).to.contain(prepareJson(dataPost))
         done()


### PR DESCRIPTION
Allows overriding the default baseUrl behaviour for the route, this includes the preview `revisions` endpoint.

```js
{
  path: '/something'
  endpoint: '/posts?123'
  options: {
    baseUrl: 'https://www.somewhere.com/wp-json/wp/v2'
  }
}
```