### PR TITLE
added cache key modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# 5.3.0 (11-11-2019)
+
+- Added feature to enable client to pass a function which modifies the cache key used, taking in the request and initial cache key as arguments
+
 # 5.2.0 (24-10-2019)
 
 - Added feature to enable client access to headers passed during requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ export default {
     Page,
     Post
   },
-  // function(req, key) to change the redis cache key generated. Uses browser request and initial cache key as arguments and must return a string which replaces the initial cache key.
+  // function(req, key) to modify the cache key. Uses browser request and initial cache key as arguments and must return a string which replaces the initial cache key.
   cacheKeyHandler: (request, cacheKey) => {
     let newKey = cacheKey
     if (request.headers['connection-speed'] > 'fast') {

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,14 @@ export default {
     Page,
     Post
   },
+  // function(req, key) to change the redis cache key generated. Uses browser request and initial cache key as arguments and must return a string which replaces the initial cache key.
+  cacheKeyHandler: (request, cacheKey) => {
+    let newKey = cacheKey
+    if (request.headers['connection-speed'] > 'fast') {
+      newKey = cacheKey + 'fastuser'
+    }
+    return newKey
+  },
   // [array] Request headers you wish to access from the front-end
   headers: ['cloudfront-viewer-country', 'connection-speed'],
   // [array] Container for route objects

--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -3,7 +3,6 @@ import chalk from 'chalk'
 import normaliseUrlPath from '../utilities/normalise-url-path'
 import CacheManager from '../utilities/cache-manager'
 import { log } from '../utilities/logger'
-import isFunction from 'lodash.isfunction'
 
 import tapestryRender from '../render/tapestry-render'
 
@@ -30,18 +29,14 @@ export default ({ server, config }) => {
       // Run cacheKeyHandler function if provided by client
       const cacheKeyHandler = config.cacheKeyHandler
       let newCacheKey = cacheKey
-      if (isFunction(cacheKeyHandler)) {
+      if (typeof cacheKeyHandler === 'function') {
         try {
-          newCacheKey = cacheKeyHandler(request, cacheKey)
-          if (typeof newCacheKey === 'string') {
-            cacheKey = newCacheKey
-          } else {
-            console.error(
-              `cacheKeyHandler() return value: expected string but received ${typeof cacheKey}`
-            )
-          }
+          newCacheKey = cacheKeyHandler({ ...request }, cacheKey)
+          if (typeof newCacheKey !== 'string')
+            throw `cacheKeyHandler() return value: expected "string" but received "${typeof newCacheKey}"`
+          cacheKey = newCacheKey
         } catch (e) {
-          console.error(`cacheKeyHandler() error: ${e}`)
+          log.error(`cacheKeyHandler() error: ${e}`)
         }
       }
 

--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -28,10 +28,9 @@ export default ({ server, config }) => {
 
       // Run cacheKeyHandler function if provided by client
       const cacheKeyHandler = config.cacheKeyHandler
-      let newCacheKey = cacheKey
       if (typeof cacheKeyHandler === 'function') {
         try {
-          newCacheKey = cacheKeyHandler({ ...request }, cacheKey)
+          const newCacheKey = cacheKeyHandler({ ...request }, cacheKey)
           if (typeof newCacheKey !== 'string')
             throw `cacheKeyHandler() return value: expected "string" but received "${typeof newCacheKey}"`
           cacheKey = newCacheKey


### PR DESCRIPTION
Cache key modifier functionality added. Client can now add a function in their tapestry config if they want to run some logic to ensure different cache keys based on the request and initial cache key.

An example of the usefulness of this feature would be the ability to generate a different cache based on the country the user is browsing from.