### PR TITLE
Fix: Cache purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# 6.1.0 (05-12-2019)
+
+- Created `cachePurgeHandler` method to allow users to declare all possible keys of a cache entry
+
 # 6.0.0 (21-11-2019)
 
 - Upgraded React, React Hot Loader, Loadable Components and Babel

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapestry-lite",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Universal React & Wordpress Renderer",
   "main": "./src/server/index.js",
   "bin": {

--- a/readme.md
+++ b/readme.md
@@ -94,16 +94,6 @@ export default {
     Page,
     Post
   },
-  // function(req, key) to modify the cache key. Uses browser request and initial cache key as arguments and must return a string which replaces the initial cache key.
-  cacheKeyHandler: (request, cacheKey) => {
-    let newKey = cacheKey
-    if (request.headers['connection-speed'] > 'fast') {
-      newKey = cacheKey + 'fastuser'
-    }
-    return newKey
-  },
-  // [array] Request headers you wish to access from the front-end
-  headers: ['cloudfront-viewer-country', 'connection-speed'],
   // [array] Container for route objects
   routes: [
     {
@@ -151,7 +141,21 @@ export default {
     forceHttps: false,
     // [boolean] Wordpress.com hosting configuration
     wordpressDotComHosting: false
-  }
+  },
+  // function(req, key) to modify the cache key. Uses browser request and initial cache key as arguments and must return a string which replaces the initial cache key.
+  cacheKeyHandler: (request, cacheKey) => {
+    let newKey = cacheKey
+    if (request.headers['region'] === 'en-us') {
+      newKey = cacheKey + ':region-us'
+    }
+    return newKey
+  },
+  // function(key) to declare all keys per cache entry. Uses initial cache key as arguments and must return a string or array representing all possible keys that could be used for the cache entry.
+  cachePurgeHandler: (key) => {
+    return [key, key + ':region-us']
+  },
+  // [array] Request headers you wish to access from the front-end
+  headers: ['region'],
 }
 ```
 

--- a/src/server/handlers/dynamic.js
+++ b/src/server/handlers/dynamic.js
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 
-import normaliseUrlPath from '../utilities/normalise-url-path'
-import CacheManager from '../utilities/cache-manager'
+import CacheManager, { getCacheKey } from '../utilities/cache-manager'
 import { log } from '../utilities/logger'
 
 import tapestryRender from '../render/tapestry-render'
@@ -24,22 +23,8 @@ export default ({ server, config }) => {
       // Set a cache key
       const currentPath = request.url.pathname || '/'
       const isPreview = Boolean(request.query && request.query.tapestry_hash)
-      let cacheKey = normaliseUrlPath(currentPath)
-
-      // Run cacheKeyHandler function if provided by client
-      const cacheKeyHandler = config.cacheKeyHandler
-      if (typeof cacheKeyHandler === 'function') {
-        try {
-          const newCacheKey = cacheKeyHandler({ ...request }, cacheKey)
-          if (typeof newCacheKey !== 'string')
-            throw `cacheKeyHandler() return value: expected "string" but received "${typeof newCacheKey}"`
-          cacheKey = newCacheKey
-        } catch (e) {
-          log.error(`cacheKeyHandler() error: ${e}`)
-        }
-      }
-
       // Is there cached HTML?
+      const cacheKey = getCacheKey(currentPath, request, config.cacheKeyHandler)
       const cacheString = await cache.get(cacheKey)
       // If there's a cache response, return the response straight away
       if (cacheString && !isPreview) {

--- a/src/server/handlers/purge.js
+++ b/src/server/handlers/purge.js
@@ -1,23 +1,33 @@
 import HTTPStatus from 'http-status'
-import CacheManager from '../utilities/cache-manager'
+import CacheManager, { getPurgeKey } from '../utilities/cache-manager'
 import { log } from '../utilities/logger'
 
-export default ({ server }) => {
+export default ({ server, config }) => {
   const cacheManager = new CacheManager()
   const purgePath = process.env.SECRET_PURGE_PATH || 'purge'
+
+  const clearCache = async key => {
+    const feedback = await cacheManager.clearCache('html', key)
+    log.silly('Purging path: ', key, 'status: ', feedback)
+  }
+
   server.route({
     method: 'GET',
     path: `/${purgePath}/{path*}`,
     handler: async (request, h) => {
       // as hapi strips the trailing slash
-      const path = request.params.path || '/'
-      const cacheFeedback = await cacheManager.clearCache('html', path)
-      log.silly('Purging path: ', path, 'status: ', cacheFeedback)
-      return h
-        .response({
-          status: `Purged ${path}`
-        })
-        .code(HTTPStatus.OK)
+      const key = getPurgeKey(
+        request.params.path || '/',
+        config.cachePurgeHandler
+      )
+
+      if (Array.isArray(key)) {
+        key.forEach(clearCache)
+      } else {
+        clearCache(key)
+      }
+
+      return h.response({ status: `Purged ${key}` }).code(HTTPStatus.OK)
     }
   })
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -45,7 +45,7 @@ class Server {
       return h.continue
     })
     // Handle server routes
-    PurgeHandler({ server })
+    PurgeHandler({ config, server })
     RedirectHandler({ config, server })
     DynamicRouteHandler({ config, server })
     // return server instance (not class)
@@ -66,7 +66,7 @@ export const registerPlugins = async ({ server, config }) => {
   // Register all required plugins before use
   await server.register(plugins)
   StaticHandler({ server })
-  ProxyHandler({ server, config })
+  ProxyHandler({ config, server })
   ApiHandler({ config, server })
 }
 


### PR DESCRIPTION
Created a new method on `tapestry.config.js` to allow users to declare all possible keys for a cache entry. This allows Tapestry to clear all instances of the cache entry and not just the default one.

Moved the heavy lifting of the cache keys and running those methods into the cache-manager utility.